### PR TITLE
refactor: remove Archon-specific references from codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,6 @@
 | Debugging | `debugger` |
 | API docs | `api-documenter` |
 | **MCP Tools** |
-| `mcp__archon__*` | `archon-manager` |
 | `mcp__github-webhook-logs-*__*` | `webhook-logs-manager` |
 | `mcp__openshift-python-wrapper__*` | `openshift-manager` |
 | `mcp__chrome-devtools__*` | `chrome-devtool-manager` |
@@ -130,25 +129,6 @@ After ANY code change:
 ❌ WRONG: Agent1 → wait → Agent2 → wait → Agent3
 ✅ RIGHT: Agent1 + Agent2 + Agent3 in ONE message
 
-## Archon (via archon-manager) - REPLACES BUILTIN TOOLS
-
-> **NOTE:** This entire Archon section only applies if `mcp__archon__*` tools are available. If Archon MCP is not configured, skip this section entirely and use TodoWrite for task tracking.
-
-**Archon is your task manager AND knowledge base. NEVER use TodoWrite.**
-
-### Task Management
-**Before ANY work:** Route to `archon-manager` agent
-
-1. Check/create task
-2. Update status to `doing`
-3. Do work via specialist agents
-4. Update status to `review` → `done`
-
-### RAG Knowledge Base
-- **Search knowledge:** Query Archon for specs, docs, context
-- **Store documents:** ALL specs/plans go in Archon, not codebase
-- **RAG queries:** Keep SHORT (2-5 keywords)
-
 ## Temp Files
 
 **ALL temp files MUST go to `/tmp/claude/`** - NEVER create temp files in project directory.
@@ -161,5 +141,5 @@ After ANY code change:
 ❌ Git commands → delegate to git-expert
 ❌ MCP tools → delegate to manager agents
 ❌ Multi-file exploration → delegate to Explore agent
-❌ TodoWrite → use Archon via archon-manager (only if Archon MCP available)
+❌ TodoWrite → delegate to specialist agents with context
 ❌ Delegating slash commands → execute them AND their internal operations DIRECTLY (see SLASH COMMAND EXECUTION section)

--- a/agents/api-documenter.md
+++ b/agents/api-documenter.md
@@ -129,11 +129,4 @@ Before delivery, ensure:
 - [ ] Code examples in multiple languages
 - [ ] Common use cases documented
 
-## Archon Integration
-
-Before implementation:
-1. Search for API documentation patterns: `rag_search_knowledge_base(query="openapi swagger patterns")`
-2. Find API examples: `rag_search_code_examples(query="rest api documentation")`
-3. Update Archon with new API documentation patterns
-
 Focus on developer experience. Include curl examples and common use cases. Make authentication setup crystal clear. Test all code examples before publishing.

--- a/agents/codebase-refactor-analyst.md
+++ b/agents/codebase-refactor-analyst.md
@@ -145,11 +145,4 @@ Before delivering analysis:
 - [ ] Quick wins highlighted
 - [ ] Long-term improvements separated
 
-## Archon Integration
-
-Before analysis:
-1. Search for refactoring patterns: `rag_search_knowledge_base(query="refactoring patterns code quality")`
-2. Check project refactoring history
-3. Update Archon with findings and patterns
-
 Provide specific, actionable recommendations with clear before/after examples where helpful. Include rationale for each suggestion and potential risks or considerations for implementation. Structure your findings in a clear, prioritized format that enables developers to tackle improvements incrementally. Focus on high-impact, low-risk improvements first.

--- a/agents/test-runner.md
+++ b/agents/test-runner.md
@@ -113,9 +113,3 @@ Before returning results:
 - [ ] Performance metrics included (execution time)
 - [ ] Coverage data extracted if available
 - [ ] Clear summary of pass/fail/skip counts
-
-## Archon Integration
-
-Before execution:
-1. Check for test patterns: `rag_search_knowledge_base(query="test execution patterns")`
-2. Update Archon with test failure patterns for future reference

--- a/scripts/rule-enforcer.py
+++ b/scripts/rule-enforcer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""PreToolUse hook - blocks TodoWrite and direct python/pip commands."""
+"""PreToolUse hook - blocks direct python/pip commands."""
 
 import json
 import sys
@@ -23,18 +23,6 @@ def main():
         input_data = json.loads(sys.stdin.read())
         tool_name = input_data.get("tool_name", "")
         tool_input = input_data.get("tool_input", {})
-
-        # Block TodoWrite - use Archon instead
-        if tool_name == "TodoWrite":
-            output = {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "permissionDecision": "deny",
-                    "permissionDecisionReason": "TodoWrite forbidden. Use Archon via archon-manager agent."
-                }
-            }
-            print(json.dumps(output))
-            sys.exit(0)
 
         # Block direct python/pip commands
         if tool_name == "Bash":

--- a/servers/code-execution/setup.sh
+++ b/servers/code-execution/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Archon UTCP Server Setup Script
+# UTCP Code-Mode Server Setup Script
 
 set -e
 
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "Archon UTCP Server Setup"
+echo "UTCP Code-Mode Server Setup"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 
@@ -31,15 +31,15 @@ fi
 echo "✓ npm version: $(npm --version)"
 echo ""
 
-# Check Archon server connectivity
-echo "Checking Archon MCP server connectivity..."
-ARCHON_URL="${ARCHON_SERVER_URL:-http://localhost:8051}"
-if curl -sf "$ARCHON_URL/health" > /dev/null 2>&1; then
-    echo "✓ Archon server is reachable at $ARCHON_URL"
+# Check for config files
+echo "Checking MCP server configurations..."
+if [ -d "configs" ] && [ "$(ls -A configs/*.json 2>/dev/null)" ]; then
+    CONFIG_COUNT=$(ls -1 configs/*.json 2>/dev/null | wc -l)
+    echo "✓ Found $CONFIG_COUNT MCP server configuration(s)"
 else
-    echo "⚠️  Warning: Cannot reach Archon server at $ARCHON_URL"
-    echo "   The server may be down or the URL may be incorrect."
-    echo "   You can set ARCHON_SERVER_URL environment variable to override."
+    echo "⚠️  Warning: No configuration files found in configs/ directory"
+    echo "   Create JSON config files in configs/ to define your MCP servers."
+    echo "   See configs/example.json.example for reference."
 fi
 echo ""
 
@@ -70,12 +70,6 @@ echo "✓ Setup complete!"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 echo "Next steps:"
-echo "  1. Start the server:        npm start"
-echo "  2. Run simple examples:     npm run example:simple"
-echo "  3. Run batched examples:    npm run example:batched"
-echo "  4. Run complex examples:    npm run example:complex"
-echo ""
-echo "Configuration:"
-echo "  Server URL: $ARCHON_URL"
-echo "  (Set ARCHON_SERVER_URL to override)"
+echo "  1. Configure MCP servers in configs/ directory"
+echo "  2. Start the server:        npm start"
 echo ""


### PR DESCRIPTION
Remove Archon integration references while keeping UTCP code-execution server as generic MCP server infrastructure:

- CLAUDE.md: remove Archon routing entry and Archon section
- scripts/rule-enforcer.py: remove TodoWrite blocking
- agents/*: remove Archon Integration sections from agent docs
- servers/code-execution/: generalize docs for any MCP server

The code-execution server remains as reusable infrastructure for integrating any MCP server via UTCP protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guides to use generic Model Context Protocol (MCP) server terminology instead of Archon-specific references.
  * Simplified setup instructions to use JSON-based configuration files in place of environment variables.

* **Refactor**
  * Removed Archon-specific integration sections from agent documentation.
  * Removed special tool-handling rules to support multi-server configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->