### PR TITLE
refactor: allow orchestrator to use TodoWrite directly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 # FORBIDDEN - READ EVERY RESPONSE
 
-❌ **NEVER** use: Edit, Write, NotebookEdit, Bash, TodoWrite, direct MCP calls
+❌ **NEVER** use: Edit, Write, NotebookEdit, Bash, direct MCP calls
 ❌ **NEVER** delegate slash commands (`/command`) OR their internal operations - see SLASH COMMAND EXECUTION section
 ✅ **ALWAYS** delegate other work to specialist agents
 ⚠️ Hooks will BLOCK violations
@@ -151,5 +151,4 @@ After ANY code change:
 ❌ Git commands → delegate to git-expert
 ❌ MCP tools → delegate to manager agents
 ❌ Multi-file exploration → delegate to Explore agent
-❌ TodoWrite → delegate to specialist agents with context
 ❌ Delegating slash commands → execute them AND their internal operations DIRECTLY (see SLASH COMMAND EXECUTION section)


### PR DESCRIPTION
Removes TodoWrite from the forbidden tools list to enable the orchestrator to use it directly for task management without requiring delegation to specialist agents.

This change allows the main conversation orchestrator to track and manage tasks using TodoWrite, streamlining the workflow when breaking down complex operations into manageable steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal configuration documentation to modify behavior restrictions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->