### PR TITLE
feat(rules): strengthen docs-fetcher routing enforcement

### DIFF
--- a/rules/10-agent-routing.md
+++ b/rules/10-agent-routing.md
@@ -38,21 +38,58 @@ Examples:
 
 ## Documentation Fetching (MANDATORY)
 
-BEFORE writing code that uses external libraries/frameworks:
-1. SPAWN `docs-fetcher` agent to get current best practices
-2. WAIT for docs context before implementing
+### Rule: NEVER Fetch Docs Directly
 
-**Triggers - MUST fetch docs when:**
-- User mentions a framework by name (FastAPI, Django, React, Express, etc.)
-- Task involves library-specific patterns (OAuth, WebSockets, ORM, etc.)
-- You're unsure about current API or best practices
-- Working with a library you haven't used recently in this conversation
+**The orchestrator MUST delegate ALL documentation fetching to `docs-fetcher` agent.**
 
-**Exceptions - Skip docs fetching when:**
+❌ **FORBIDDEN** - Orchestrator using WebFetch for external docs:
+```
+WebFetch(https://react.dev/...)
+WebFetch(https://fastapi.tiangolo.com/...)
+WebFetch(https://ohmyposh.dev/...)
+```
+
+✅ **REQUIRED** - Delegate to docs-fetcher:
+```
+Task(subagent_type="docs-fetcher", prompt="Fetch Oh My Posh configuration docs...")
+```
+
+### Why This Matters
+
+- docs-fetcher tries `llms.txt` first (optimized for LLMs)
+- docs-fetcher extracts only relevant sections
+- docs-fetcher provides structured, actionable output
+- Direct WebFetch wastes tokens on full HTML pages
+
+### When to Spawn docs-fetcher
+
+**MUST delegate when:**
+- Fetching library/framework documentation (React, FastAPI, Django, etc.)
+- Looking up configuration guides (Oh My Posh, Starship, etc.)
+- Getting API references or usage examples
+- User asks about external tool documentation
+- You need current best practices for a library
+
+**Exceptions - Skip docs-fetcher when:**
 - Standard library only (no external dependencies)
 - User explicitly says "skip docs" or "I know the API"
 - Simple operations with obvious patterns
 - Already fetched docs for this library in current conversation
+
+### Workflow
+
+```
+Need external docs?
+       ↓
+  ┌────────────────────────────────────┐
+  │  DELEGATE to docs-fetcher agent    │
+  │  DO NOT use WebFetch directly      │
+  └────────────────────────────────────┘
+       ↓
+Wait for structured response
+       ↓
+Use context for implementation
+```
 
 ## Fallback
 


### PR DESCRIPTION
## Summary

Strengthens the docs-fetcher routing rules to prevent the orchestrator from using WebFetch directly for external documentation.

### Changes Made

- **Added explicit prohibition**: Orchestrator MUST NOT use WebFetch for external docs
- **Required delegation pattern**: Must delegate to docs-fetcher agent instead
- **Rationale section**: Explains why docs-fetcher is preferred (llms.txt priority, structured output, token efficiency)
- **Visual workflow diagram**: Shows mandatory delegation flow
- **Enhanced trigger conditions**: Clarifies when to use docs-fetcher vs when to skip

### Why This Matters

The docs-fetcher agent is specifically designed to:
1. Try `llms.txt` first (LLM-optimized documentation format)
2. Extract only relevant sections from docs
3. Provide structured, actionable output
4. Avoid wasting tokens on full HTML pages

Direct WebFetch bypasses these optimizations and leads to inefficient token usage.

### Impact

This change ensures consistent, efficient documentation retrieval across all orchestrator operations by enforcing the use of the specialized docs-fetcher agent.

## Test Plan

- [x] Verify rule file syntax is correct
- [ ] Test that orchestrator delegates to docs-fetcher for external docs
- [ ] Verify WebFetch is blocked for documentation URLs
- [ ] Confirm llms.txt priority works as expected