### PR TITLE
fix(docs): wrap bare URL in markdown link syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ The Graphiti Memory Server enables persistent knowledge graph storage across Cla
 
 To use `/analyze-project` and graphiti-memory features, you need to set up the Graphiti MCP server:
 
-**Graphiti MCP Server**: https://github.com/getzep/graphiti/tree/main/mcp_server
+**Graphiti MCP Server**: [Graphiti MCP server repository](https://github.com/getzep/graphiti/tree/main/mcp_server)
 
 Follow the installation instructions in the repository to configure the MCP server, including:
 - Neo4j database setup (local or remote)


### PR DESCRIPTION
Fixes MD034 lint violation flagged by CodeRabbit on PR #27.

**Change:** Wrapped bare URL in proper markdown link syntax for the Graphiti MCP server reference.

Addresses: https://github.com/myk-org/claude-code-config/pull/27#discussion_r2655991477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved README formatting for enhanced readability and accessibility of reference links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->