### PR TITLE
fix(agents): remove non-functional git -C rule

### DIFF
--- a/agents/00-base-rules.md
+++ b/agents/00-base-rules.md
@@ -4,35 +4,6 @@
 
 ---
 
-## Git Command Rules
-
-### NEVER USE `git -C` (STRICT RULE)
-
-When running git commands:
-
-🚨 **YOU ARE ALREADY IN THE REPOSITORY. RUN GIT COMMANDS DIRECTLY.**
-
-```bash
-# ✅ CORRECT - Run directly in current directory
-git status
-git diff
-git log --oneline -10
-git show HEAD
-
-# ❌ FORBIDDEN - Never use -C for current repository
-git -C /path/to/repo status
-git -C . diff
-git -C "$PWD" log
-```
-
-**The `-C` flag is FORBIDDEN unless:**
-1. The orchestrator **EXPLICITLY** asks you to operate on an external repository
-2. The repository is at a **DIFFERENT PATH** than the current working directory (e.g., `/tmp/claude/some-other-repo`)
-
-**If no external repository is mentioned, NEVER use `-C`.**
-
----
-
 ## Action-First Principle
 
 All agents should:


### PR DESCRIPTION
## Summary
- Remove the "Git Command Rules" section from `agents/00-base-rules.md`
- The git -C prohibition was not working as intended

## Changes
- Removed lines 7-33 from `agents/00-base-rules.md` (the git -C rule section)
- Kept other base rules: Action-First Principle, Separation of Concerns, Communication Style

## Test plan
- [x] Verify markdown structure is correct
- [x] Code review passed
- [ ] Agents no longer reference the removed rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified agent configuration documentation by removing Git command usage restrictions and related guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->