### PR TITLE
fix(scripts): require review ID and filter resolved comments

### DIFF
--- a/commands/github-coderabbitai-review-handler.md
+++ b/commands/github-coderabbitai-review-handler.md
@@ -44,24 +44,34 @@ $MAIN_SCRIPT $PR_INFO_SCRIPT <USER_INPUT_IF_PROVIDED>
 
 ---
 
-**If user provides input (review ID, URL, or commit SHA):**
+**User MUST provide a review ID or review URL:**
 
 ```bash
-# User provided: 3379917343
+# User provided review ID:
 $MAIN_SCRIPT $PR_INFO_SCRIPT 3379917343
 
-# User provided: https://github.com/owner/repo/pull/123#pullrequestreview-3379917343
+# User provided review URL:
 $MAIN_SCRIPT $PR_INFO_SCRIPT "https://github.com/owner/repo/pull/123#pullrequestreview-3379917343"
-
-# User provided: 6c544434d69b2ef76441949cfe839167b7de775a
-$MAIN_SCRIPT $PR_INFO_SCRIPT 6c544434d69b2ef76441949cfe839167b7de775a
 ```
 
 **If user provides NO input:**
 
-```bash
-# Gets latest commit comments automatically
-$MAIN_SCRIPT $PR_INFO_SCRIPT
+The review ID or URL is REQUIRED. If the user doesn't provide one, instruct them:
+
+```text
+To use this command, you need to provide a CodeRabbit review ID or URL.
+
+How to get the review URL:
+1. Go to the GitHub PR page
+2. Find the CodeRabbit review you want to process
+3. Click on the review timestamp/link
+4. Copy the URL from your browser (it will contain #pullrequestreview-XXXXXXXXXX)
+
+Example:
+  /github-coderabbitai-review-handler https://github.com/owner/repo/pull/123#pullrequestreview-3379917343
+
+Or just provide the review ID number:
+  /github-coderabbitai-review-handler 3379917343
 ```
 
 **THAT'S ALL. DO NOT extract scripts, get PR info, or do ANY bash manipulation. The scripts handle


### PR DESCRIPTION
## Summary
- Removes "get latest" support - review ID/URL is now **required**
- Adds CodeRabbit validation (warns if review is not from coderabbitai[bot])
- Optimizes API calls by caching review JSON (avoids duplicate API calls)
- Adds resolved comment filtering using GraphQL API
- Only counts resolved comments from the specific review, not entire PR
- Extracts duplicate usage message into `show_usage()` function
- Adds explicit error handling for API failures
- Updates command documentation with user instructions

## Breaking Change
Users must now provide a review ID or URL when invoking the command. The "get latest review" functionality has been removed because it was unreliable (reviews on older commits wouldn't be found).

## How to get the review URL
1. Go to the GitHub PR page
2. Find the CodeRabbit review you want to process
3. Click on the review timestamp/link
4. Copy the URL (contains `#pullrequestreview-XXXXXXXXXX`)

## Test plan
- [x] Code review passed
- [x] All 338 tests pass
- [x] Manual test with valid review ID returns correct data
- [x] Manual test without review ID shows helpful usage message
- [x] Manual test with invalid review ID shows clear error
- [x] Resolved comments are filtered correctly (shows count from specific review only)

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit requirement for users to provide a review ID or URL as input.
  * Included step-by-step guidance and formatted usage examples for obtaining review information.
  * Added validation to confirm reviews originate from CodeRabbit.

* **Bug Fixes**
  * Implemented filtering to exclude resolved comments from output.

* **Documentation**
  * Updated command documentation with clearer field labels and usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->