### PR TITLE
feat(github-release): show proposed version inline in confirmation

### DIFF
--- a/commands/github-release.md
+++ b/commands/github-release.md
@@ -348,7 +348,7 @@ Do NOT create any release without user confirmation.
 ---
 
 **Options**:
-- `yes` or `y` - Create release with proposed version
+- `yes` or `y` - Create release with proposed version ({proposed_version})
 - `major` - Override to MAJOR version bump
 - `minor` - Override to MINOR version bump
 - `patch` - Override to PATCH version bump


### PR DESCRIPTION
## Summary
- Show proposed version inline in the first confirmation option
- Changes "Create release with proposed version" to "Create release with proposed version (v1.2.3)"
- Saves user time from scrolling up to find the version

## Test plan
- [x] Code review passed
- [x] All 338 tests pass

Closes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release command documentation to clarify display of the proposed version in confirmation options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->