### PR TITLE
chore: bump version to 1.1.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,25 +8,25 @@
       "name": "myk-qodo",
       "source": "./plugins/myk-qodo",
       "description": "Qodo AI code review integration",
-      "version": "1.1.7"
+      "version": "1.1.8"
     },
     {
       "name": "myk-github",
       "source": "./plugins/myk-github",
       "description": "GitHub operations - PR reviews, releases, review handling",
-      "version": "1.1.7"
+      "version": "1.1.8"
     },
     {
       "name": "myk-review",
       "source": "./plugins/myk-review",
       "description": "Local code review and review database operations",
-      "version": "1.1.7"
+      "version": "1.1.8"
     },
     {
       "name": "myk-cursor",
       "source": "./plugins/myk-cursor",
       "description": "Run one-shot prompts via Cursor agent CLI",
-      "version": "1.1.7"
+      "version": "1.1.8"
     }
   ]
 }

--- a/myk_claude_tools/__init__.py
+++ b/myk_claude_tools/__init__.py
@@ -1,3 +1,3 @@
 """myk-claude-tools: CLI utilities for Claude Code plugins."""
 
-__version__ = "0.1.0"
+__version__ = "1.1.8"

--- a/plugins/myk-cursor/.claude-plugin/plugin.json
+++ b/plugins/myk-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "myk-cursor",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Run one-shot prompts via Cursor agent CLI from Claude Code",
   "author": { "name": "myk-org" },
   "repository": "https://github.com/myk-org/claude-code-config",

--- a/plugins/myk-github/.claude-plugin/plugin.json
+++ b/plugins/myk-github/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "myk-github",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "GitHub operations for Claude Code - PR reviews, releases, and review handling",
   "author": {
     "name": "myk-org"

--- a/plugins/myk-qodo/.claude-plugin/plugin.json
+++ b/plugins/myk-qodo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "myk-qodo",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Qodo AI code review integration for Claude Code",
   "author": {
     "name": "myk-org"

--- a/plugins/myk-review/.claude-plugin/plugin.json
+++ b/plugins/myk-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "myk-review",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Local code review and review database operations for Claude Code",
   "author": {
     "name": "myk-org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "myk-claude-tools"
-version = "1.1.7"
+version = "1.1.8"
 description = "CLI utilities for Claude Code plugins"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump for v1.1.8 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.1.8 across all plugins and the main module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->