### PR TITLE
fix: default release title to tag name (issue #134)

### DIFF
--- a/myk_claude_tools/release/commands.py
+++ b/myk_claude_tools/release/commands.py
@@ -33,13 +33,22 @@ def release_create(
     owner_repo: str,
     tag: str,
     changelog_file: str,
+    *,
     prerelease: bool,
     draft: bool,
     target: str | None,
     title: str | None,
 ) -> None:
     """Create a GitHub release."""
-    create_run(owner_repo, tag, changelog_file, prerelease, draft, target, title)
+    create_run(
+        owner_repo=owner_repo,
+        tag=tag,
+        changelog_file=changelog_file,
+        prerelease=prerelease,
+        draft=draft,
+        target=target,
+        title=title,
+    )
 
 
 @release.command("detect-versions")

--- a/myk_claude_tools/release/create.py
+++ b/myk_claude_tools/release/create.py
@@ -152,7 +152,7 @@ def create_release(
         "--notes-file",
         changelog_file,
         "--title",
-        title if title else tag,
+        title.strip() if title and title.strip() else tag,
     ]
 
     if target:


### PR DESCRIPTION
## Summary

- Add `--title` option to `myk-claude-tools release create` command
- Default release title to the tag name when no title is specified
- Fixes empty title on GitHub release pages

Closes #134

## Test Plan

- [x] 592 tests pass
- [x] ruff/mypy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `--title` option to release creation command, enabling custom release titles (defaults to tag name if not specified)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->