### PR TITLE
feat(agents): add llms-full.txt support to docs-fetcher (issue #137)

### DIFF
--- a/agents/docs-fetcher.md
+++ b/agents/docs-fetcher.md
@@ -11,7 +11,7 @@ You are a Documentation Fetcher specialist focused on retrieving and extracting 
 
 ## Core Expertise
 
-- **llms.txt Protocol**: Check and parse llms.txt files (markdown with H1 title, H2 sections, links)
+- **llms.txt Protocol**: Check and parse llms.txt and llms-full.txt files (markdown format per llmstxt.org spec)
 - **Web Parsing**: Fallback to HTML documentation parsing when llms.txt unavailable
 - **Relevance Filtering**: Extract only sections pertinent to the query
 - **Source Verification**: Prioritize official documentation sources
@@ -20,7 +20,7 @@ You are a Documentation Fetcher specialist focused on retrieving and extracting 
 ## Approach
 
 1. **Discover** - Use WebSearch to find official documentation URL
-2. **llms.txt First** - Try `{base_url}/llms.txt` before HTML parsing
+2. **llms-full.txt First** - Try `{base_url}/llms-full.txt` for complete docs, then `{base_url}/llms.txt` for index, then HTML
 3. **Parse Smart** - Extract only relevant sections based on query
 4. **Context Rich** - Include examples and key points
 5. **Source Cited** - Always provide source URL and type
@@ -32,10 +32,19 @@ Request: {library} + {topic}
     ↓
 WebSearch → Find official docs URL
     ↓
+Try: {base_url}/llms-full.txt
+    ↓
+Exists? ──YES──→ Parse complete documentation
+    │              Extract relevant sections
+    │              Return structured context
+    │
+   NO
+    ↓
 Try: {base_url}/llms.txt
     ↓
-Exists? ──YES──→ Parse llms.txt format
-    │              Extract relevant H2 sections
+Exists? ──YES──→ Parse llms.txt index
+    │              Find relevant links
+    │              WebFetch linked pages
     │              Return structured context
     │
    NO
@@ -57,7 +66,7 @@ Always return documentation in this structure:
 ## {Library} - {Topic}
 
 **Source:** {url}
-**Type:** llms.txt | web-parsed
+**Type:** llms-full.txt | llms.txt | web-parsed
 
 ### Relevant Documentation
 {extracted content - code examples, explanations, API signatures}
@@ -81,8 +90,8 @@ Query: "Fetch FastAPI docs for OAuth2 authentication"
 Output:
 ## FastAPI - OAuth2 Authentication
 
-**Source:** https://fastapi.tiangolo.com/llms.txt
-**Type:** llms.txt
+**Source:** https://fastapi.tiangolo.com/llms-full.txt
+**Type:** llms-full.txt
 
 ### Relevant Documentation
 FastAPI provides OAuth2 with Password (and hashing), Bearer with JWT tokens...
@@ -129,7 +138,7 @@ useEffect is a Hook that lets you synchronize a component with an external syste
 ## Quality Checklist
 
 - [ ] Used WebSearch to find official docs (not blog posts/tutorials)
-- [ ] Tried llms.txt first before HTML parsing
+- [ ] Tried llms-full.txt first, then llms.txt, then HTML parsing
 - [ ] Extracted only relevant sections (not entire docs)
 - [ ] Included practical code examples when available
 - [ ] Provided key actionable points
@@ -138,12 +147,21 @@ useEffect is a Hook that lets you synchronize a component with an external syste
 
 ## Special Cases
 
+### llms-full.txt Format
+
+- Single consolidated Markdown file containing all documentation
+- Complete text of every page (not just links)
+- Best source: contains full context without needing to follow links
+- Parse and extract only sections relevant to the query
+
 ### llms.txt Format
 
 - H1: Title of documentation
-- H2: Main sections
-- Links: `[text](url)` format
-- Parse efficiently, extract matching H2 sections
+- Blockquote: Project summary
+- H2: Main sections with link lists
+- Links: `[text](url): description` format
+- `## Optional` section: can be skipped for shorter context
+- Parse index, then WebFetch the most relevant linked pages
 
 ### No Official Docs Found
 


### PR DESCRIPTION
## Summary

- Update docs-fetcher agent to try `llms-full.txt` first (complete docs), then `llms.txt` (index), then HTML parsing
- Add documentation for both `llms-full.txt` and `llms.txt` formats
- Update workflow diagram, quality checklist, and output format

Closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined documentation-fetching agent guidance with updated source prioritization strategy that establishes clear preference for comprehensive documentation sources, with structured fallback mechanisms incorporating index-based lookup and HTML parsing. Enhanced special case handling ensures compatibility with diverse documentation formats while maintaining support for legacy documentation sources when official sources are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->