### PR TITLE
fix(review-handler): enforce exact reviewer suggestions, no corner-cutting (issue #140)

### DIFF
--- a/AI_REVIEW.md
+++ b/AI_REVIEW.md
@@ -486,6 +486,15 @@ This enforces that orchestrator delegates work instead of doing it directly.
 It is no longer tracked in this repository and therefore does not need to be kept in sync with `AI_REVIEW.md`.
 Update `AI_REVIEW.md` when modifying shared project context or guidelines.
 
+## Handling Review Feedback
+
+When fixing reviewer comments (human, CodeRabbit, Qodo):
+
+- If the reviewer provides a specific code suggestion or diff, implement it exactly — not your own interpretation
+- Do NOT simplify, minimize, or "half-fix" the suggestion
+- After fixing, verify your code matches what the reviewer asked for, not just "addresses the concern"
+- **NO SKIP WITHOUT USER APPROVAL:** If you disagree with a suggestion, ASK THE USER before skipping, partially fixing, or applying a minimum-viable fix
+
 ---
 
 ## Common Tasks

--- a/plugins/myk-github/commands/review-handler.md
+++ b/plugins/myk-github/commands/review-handler.md
@@ -86,10 +86,7 @@ For each approved comment, delegate to appropriate specialist agent.
 - If the reviewer provides a specific code suggestion or diff, implement IT exactly — not your own interpretation
 - Do NOT simplify, minimize, or "half-fix" the suggestion
 - After fixing, verify your code matches what the reviewer asked for, not just "addresses the concern"
-- If you disagree with the suggestion, ASK THE USER before skipping — never skip or water-down without user approval
-
-**NO SKIP WITHOUT USER APPROVAL.** If the AI disagrees with a reviewer's suggestion, it must ask the user first.
-It cannot decide on its own to skip, partially fix, or do a "minimum viable fix."
+- **NO SKIP WITHOUT USER APPROVAL:** If you disagree with the suggestion, ASK THE USER before skipping, partially fixing, or applying a minimum-viable fix
 
 ### Phase 4: Review Unimplemented
 


### PR DESCRIPTION
## Summary

- Expand Phase 3 (Execute Approved Tasks) of the review-handler command with explicit rules for fixing review comments
- Enforce implementing reviewer's exact suggestions, not simplified interpretations
- Require user approval before skipping or partially fixing any suggestion

Closes #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added mandatory guidance requiring exact implementation of reviewer-provided suggestions and verification that changes precisely match those requests.
  * Enforced a "no skip without user approval" rule: ask the user before skipping, partially fixing, or applying minimal fixes.
  * Inserted the new guidance in two places to ensure visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->