### PR TITLE
fix(cursor): address PR #144 review feedback (issue #143)

### DIFF
--- a/plugins/myk-cursor/commands/prompt.md
+++ b/plugins/myk-cursor/commands/prompt.md
@@ -120,6 +120,10 @@ Use `--continue` only when the prior successful `agent` call used the same
 mode (both non-fix or both `--fix`). Do not use `--continue` when switching
 between modes.
 
+**Why:** Fix mode and non-fix mode use different invocation patterns. A fix-mode
+session has file-write context that doesn't apply to read-only queries, and
+vice versa. Mixing sessions could cause unexpected behavior.
+
 ### Step 2d: Workspace Safety Check (--fix mode only)
 
 **Skip this step if --fix was NOT passed.**
@@ -285,6 +289,9 @@ git diff
 git diff --cached --stat
 git diff --cached
 ```
+
+Use `git status --short` to detect newly created untracked files that
+`git diff` won't show.
 
 If either the unstaged diff or staged diff is empty, omit that section from
 the report.


### PR DESCRIPTION
## Summary

Re-applies review fixes that were lost when PR #144 was merged before committing:

- Document why `--continue` is not reused across fix/non-fix mode switches
- Add note about using `git status --short` to detect untracked files created by Cursor

## Context

These fixes address CodeRabbit review feedback from PR #144.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Enhanced guidance clarifying how different operational modes interact and behave when combined.
* Expanded workspace safety checks with detailed user prompts and decision processes for various git scenarios.
* Improved file detection workflow guidance to identify newly created files during analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->