### PR TITLE
feat(cursor): smart session management using create-chat and resume

### DIFF
--- a/plugins/myk-cursor/commands/prompt.md
+++ b/plugins/myk-cursor/commands/prompt.md
@@ -160,14 +160,15 @@ For each new `/myk-cursor:prompt` call, decide:
 #### Creating a New Session
 
 ```bash
-CHAT_ID=$(agent create-chat 2>&1)
-status=$?
-if [ $status -ne 0 ]; then
-  echo "$CHAT_ID" >&2
-  exit $status
+CHAT_ID=$(agent create-chat)
+if [ $? -ne 0 ]; then
+  # stderr was already emitted by agent create-chat
+  echo "Failed to create chat session" >&2
+  exit 1
 fi
-if [ -z "$CHAT_ID" ]; then
-  echo "agent create-chat did not return a chat ID" >&2
+# Validate UUID format
+if ! echo "$CHAT_ID" | grep -qE '^[0-9a-f-]{36}$'; then
+  echo "agent create-chat returned invalid ID: $CHAT_ID" >&2
   exit 1
 fi
 ```
@@ -246,12 +247,8 @@ Follow this decision process:
      diff summary may include pre-existing edits
    - **Abort** — Stop here to handle changes manually
 3. Handle the response as follows:
-   - If the user selects **Commit first (Recommended)**, collect changed
-     paths from `git status --porcelain -z` and stage them using a
-     NUL-safe mechanism (e.g., pipe to `xargs -0 git add --`). This
-     correctly handles filenames with spaces, renames, and deletions.
-     Do **not** parse human-oriented `git status --short` for staging.
-     Then create a checkpoint commit with the message
+   - If the user selects **Commit first (Recommended)**, stage all changes
+     with `git add -A` and create a checkpoint commit with the message
      `chore: checkpoint before cursor --fix`.
      After the commit, verify with `git status --porcelain -z` that the
      output is empty (workspace is clean) before proceeding.


### PR DESCRIPTION
## Summary

Closes #147

Replace `--continue` (implicit "last session" resume) with explicit `agent create-chat` + `--resume <chatId>` for Cursor session management in the `myk-cursor:prompt` plugin.

### What changed

- **Smart session routing** — AI decides whether each `/myk-cursor:prompt` call should resume an existing session or start a new one, based on prompt intent and topic matching
- **Session registry** — Tracks chat ID, topic summary, and mode for each successful session; only successful sessions (is_error: false) are eligible for reuse
- **Convention guards** — Fix-mode prompts now include project conventions as constraints, preventing Cursor from reverting intentional design decisions
- **Improved dirty-worktree flow** — "Commit first" is now the default/recommended option, and the AI creates the checkpoint commit automatically (explicit staging by path, verification, abort on failure)
- **Error handling** — `agent create-chat` failures are validated and handled with clear abort messages
- **Tiebreaker rule** — When multiple sessions match, prefer the most recently used

### Files changed

- `plugins/myk-cursor/commands/prompt.md` — All changes in this single file

## Test plan

- [ ] Run `/myk-cursor:prompt <question>` — should create a new session via `create-chat`
- [ ] Run a follow-up `/myk-cursor:prompt` on the same topic — should resume the previous session
- [ ] Run `/myk-cursor:prompt` on a different topic — should create a new session
- [ ] Run `/myk-cursor:prompt --fix review` with dirty worktree — should offer "Commit first" as default
- [ ] Select "Commit first" — AI should create checkpoint commit automatically
- [ ] Verify convention guards are included in fix-mode prompts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised session management workflow to emphasize explicit session lifecycle, clear rules for resuming vs. creating sessions, and visible session info (ID, topic, last used, new vs resumed).
  * Enforced use of resume semantics for continuations and fix flows, plus a trust-errors retry flow.
  * Expanded workspace safety checks with Commit/Continue/Abort choices and handling.
  * Added guidance for enriched prompts (convention guards) and session-aware diff summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->