### PR TITLE
fix(release): use branch+PR flow instead of direct push to protected branches

### DIFF
--- a/plugins/myk-github/commands/release.md
+++ b/plugins/myk-github/commands/release.md
@@ -125,13 +125,32 @@ Parse the JSON output from bump-version. Only `git add` the files listed in the
 `updated[]` array. If `skipped[]` is non-empty, inform the user which files were
 skipped and why before proceeding.
 
-Then commit and push the version bump:
+Then create a branch, commit, push, and merge via PR:
 
 ```bash
+git checkout -b chore/bump-version-<VERSION>
 git add <updated-files>
 git commit -m "chore: bump version to <VERSION>"
-git push
+git push -u origin chore/bump-version-<VERSION>
 ```
+
+Create a PR and merge it:
+
+```bash
+gh pr create --title "chore: bump version to <VERSION>" \
+  --body "Bump version to <VERSION>" --base <target_branch>
+gh pr merge --merge --admin --delete-branch
+```
+
+After merge, sync the local target branch:
+
+```bash
+git checkout <target_branch>
+git pull origin <target_branch>
+```
+
+Where `<target_branch>` is the branch from Phase 1 validation
+(default branch or `--target` value).
 
 ### Phase 6: Create Release
 


### PR DESCRIPTION
Phase 5 of the release plugin previously tried to commit and push directly to the target branch, which fails with branch protection. Now creates a chore branch, pushes, creates a PR, and merges via gh CLI instead.