### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/myk_claude_tools/__init__.py
+++ b/myk_claude_tools/__init__.py
@@ -1,3 +1,3 @@
 """myk-claude-tools: CLI utilities for Claude Code plugins."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/plugins/myk-cursor/.claude-plugin/plugin.json
+++ b/plugins/myk-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "myk-cursor",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Run prompts via Cursor agent CLI with --fix mode and --peer AI-to-AI review",
   "author": { "name": "myk-org" },
   "repository": "https://github.com/myk-org/claude-code-config",

--- a/plugins/myk-github/.claude-plugin/plugin.json
+++ b/plugins/myk-github/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "myk-github",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "GitHub operations for Claude Code - PR reviews, releases, and review handling",
   "author": {
     "name": "myk-org"

--- a/plugins/myk-qodo/.claude-plugin/plugin.json
+++ b/plugins/myk-qodo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "myk-qodo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Qodo AI code review integration for Claude Code",
   "author": {
     "name": "myk-org"

--- a/plugins/myk-review/.claude-plugin/plugin.json
+++ b/plugins/myk-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "myk-review",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Local code review and review database operations for Claude Code",
   "author": {
     "name": "myk-org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "myk-claude-tools"
-version = "1.3.0"
+version = "1.3.1"
 description = "CLI utilities for Claude Code plugins"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bump version to 1.3.1 in pyproject.toml, __init__.py, and all plugin.json files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 1.3.1 released with updates across all modules and plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->