### PR TITLE
chore: align all plugin versions to 1.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "myk-qodo",
       "source": "./plugins/myk-qodo",
       "description": "Qodo AI code review integration",
-      "version": "1.2.0"
+      "version": "1.4.1"
     },
     {
       "name": "myk-github",
@@ -20,13 +20,13 @@
       "name": "myk-review",
       "source": "./plugins/myk-review",
       "description": "Local code review and review database operations",
-      "version": "1.2.0"
+      "version": "1.4.1"
     },
     {
       "name": "myk-cursor",
       "source": "./plugins/myk-cursor",
       "description": "Run prompts via Cursor agent CLI with optional --fix mode for direct file changes",
-      "version": "1.2.0"
+      "version": "1.4.1"
     }
   ]
 }

--- a/plugins/myk-cursor/.claude-plugin/plugin.json
+++ b/plugins/myk-cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "myk-cursor",
-  "version": "1.3.1",
+  "version": "1.4.1",
   "description": "Run prompts via Cursor agent CLI with --fix mode and --peer AI-to-AI review",
   "author": { "name": "myk-org" },
   "repository": "https://github.com/myk-org/claude-code-config",

--- a/plugins/myk-qodo/.claude-plugin/plugin.json
+++ b/plugins/myk-qodo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "myk-qodo",
-  "version": "1.3.1",
+  "version": "1.4.1",
   "description": "Qodo AI code review integration for Claude Code",
   "author": {
     "name": "myk-org"

--- a/plugins/myk-review/.claude-plugin/plugin.json
+++ b/plugins/myk-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "myk-review",
-  "version": "1.3.1",
+  "version": "1.4.1",
   "description": "Local code review and review database operations for Claude Code",
   "author": {
     "name": "myk-org"


### PR DESCRIPTION
Sync myk-cursor, myk-qodo, and myk-review plugin versions to 1.4.1 to match myk-github and the repo version. Also sync marketplace.json entries that were stuck at 1.2.0.