### PR TITLE
feat(review-handler): reply to all review comments including body comments

### DIFF
--- a/myk_claude_tools/reviews/post.py
+++ b/myk_claude_tools/reviews/post.py
@@ -251,6 +251,204 @@ def apply_updates_to_json(json_path: Path, updates: list[dict[str, Any]]) -> Non
         sys.exit(1)
 
 
+def _build_comment_section(entry: dict[str, Any], max_section_len: int) -> str:
+    """Build a formatted markdown section for a single body comment entry.
+
+    Args:
+        entry: Entry dict with {"data": thread_data, "cat": category, "idx": index}
+        max_section_len: Maximum allowed length for the section text.
+
+    Returns:
+        Formatted section text.
+    """
+    truncated_suffix = "\n...[truncated]"
+    comment = entry["data"]
+    path = comment.get("path", "unknown")
+    line_num = comment.get("line", "")
+    status = comment.get("status", "")
+    reply = comment.get("reply", "") or comment.get("skip_reason", "")
+    comment_type = comment.get("type", "").replace("_", " ").replace("comment", "").strip()
+
+    body = comment.get("body", "")
+    summary = body.split("\n")[0][:100] if body else "No description"
+    summary = summary.strip("*").strip()
+
+    location = f"`{path}:{line_num}`" if line_num else f"`{path}`"
+    type_label = f" ({comment_type})" if comment_type else ""
+
+    section_lines = [f"### {location}{type_label} — {summary}"]
+    if status == "addressed":
+        section_lines.append(f"> Addressed: {reply}" if reply else "> Addressed.")
+    elif status == "skipped":
+        section_lines.append(f"> Skipped: {reply}" if reply else "> Skipped.")
+    elif status == "not_addressed":
+        section_lines.append(f"> Not addressed: {reply}" if reply else "> Not addressed.")
+    elif status == "failed":
+        section_lines.append(f"> Retry: {reply}" if reply else "> Retry.")
+    section_lines.append("")
+
+    section_text = "\n".join(section_lines)
+    if len(section_text) > max_section_len:
+        keep = max(0, max_section_len - len(truncated_suffix))
+        section_text = section_text[:keep] + truncated_suffix
+
+    return section_text
+
+
+def _chunk_sections(
+    header: str,
+    sections: list[tuple[str, dict[str, Any]]],
+    max_len: int,
+) -> list[list[tuple[str, dict[str, Any]]]]:
+    """Split sections into chunks that fit within the GitHub comment size limit.
+
+    Args:
+        header: Comment header text (included in each chunk's size budget).
+        sections: List of (section_text, entry) tuples.
+        max_len: Maximum allowed body length per chunk.
+
+    Returns:
+        List of chunks, where each chunk is a list of (section_text, entry) tuples.
+    """
+    chunks: list[list[tuple[str, dict[str, Any]]]] = []
+    current_chunk: list[tuple[str, dict[str, Any]]] = []
+    current_size = len(header)
+
+    for section_text, entry in sections:
+        section_size = len(section_text)
+        if current_chunk and current_size + section_size > max_len:
+            chunks.append(current_chunk)
+            current_chunk = []
+            current_size = len(header)
+        current_chunk.append((section_text, entry))
+        current_size += section_size
+
+    if current_chunk:
+        chunks.append(current_chunk)
+
+    return chunks
+
+
+def _post_chunk(
+    owner: str,
+    repo: str,
+    pr_number: str | int,
+    reviewer: str,
+    chunk: list[tuple[str, dict[str, Any]]],
+    header: str,
+    chunk_idx: int,
+    total_chunks: int,
+    max_len: int,
+) -> tuple[bool, list[dict[str, Any]]]:
+    """Post a single consolidated comment chunk to a pull request.
+
+    Args:
+        owner: Repository owner.
+        repo: Repository name.
+        pr_number: Pull request number.
+        reviewer: Reviewer username.
+        chunk: List of (section_text, entry) tuples for this chunk.
+        header: Comment header text.
+        chunk_idx: Zero-based index of this chunk.
+        total_chunks: Total number of chunks being posted.
+        max_len: Maximum allowed body length.
+
+    Returns:
+        Tuple of (success, list of posted_at update dicts).
+    """
+    truncated_suffix = "\n...[truncated]"
+    chunk_body = header + "".join(text for text, _ in chunk).strip()
+    if total_chunks > 1:
+        chunk_body = f"(Part {chunk_idx + 1}/{total_chunks})\n\n" + chunk_body
+
+    if len(chunk_body) > max_len:
+        keep = max(0, max_len - len(truncated_suffix))
+        chunk_body = chunk_body[:keep] + truncated_suffix
+
+    posted_updates: list[dict[str, Any]] = []
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{owner}/{repo}/issues/{pr_number}/comments", "-f", f"body={chunk_body}"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode == 0:
+            chunk_count = len(chunk)
+            eprint(f"Posted consolidated reply for {chunk_count} body comment(s) mentioning @{reviewer}")
+            ts = get_utc_timestamp()
+            for _, entry in chunk:
+                posted_updates.append({
+                    "cat": entry["cat"],
+                    "idx": entry["idx"],
+                    "field": "posted_at",
+                    "ts": ts,
+                })
+            return True, posted_updates
+        eprint(f"Error posting consolidated reply for @{reviewer}: {result.stderr}")
+        return False, []
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        eprint(f"Error posting consolidated reply for @{reviewer}: {e}")
+        return False, []
+
+
+def post_body_comment_replies(
+    owner: str,
+    repo: str,
+    pr_number: str | int,
+    body_comments: dict[str, list[dict[str, Any]]],
+) -> tuple[int, list[dict[str, Any]]]:
+    """Post consolidated PR comments for body comments (outside_diff, nitpick, duplicate).
+
+    Groups comments by reviewer author and posts one or more PR comments per reviewer
+    mentioning the reviewer so they know the comments were reviewed.
+    Chunks into multiple comments if the combined body exceeds GitHub's size limit.
+
+    Args:
+        owner: Repository owner
+        repo: Repository name
+        pr_number: Pull request number
+        body_comments: Dict mapping reviewer username to list of entry dicts
+            Each entry has {"data": thread_data, "cat": category, "idx": index}
+
+    Returns:
+        Tuple of (number of chunks successfully posted, list of posted_at updates)
+    """
+    max_len = 55000  # Leave margin below GitHub's ~65KB limit
+    header_template = "@{reviewer}\n\nThe following review comments were reviewed and a decision was made:\n\n"
+    posted = 0
+    posted_updates: list[dict[str, Any]] = []
+
+    for reviewer, entries in body_comments.items():
+        if not entries:
+            continue
+
+        header = header_template.format(reviewer=reviewer)
+        part_prefix_budget = 32  # "(Part N/M)\n\n" safety margin
+        max_section_len = max_len - len(header) - part_prefix_budget
+
+        # Build individual sections for each comment
+        sections: list[tuple[str, dict[str, Any]]] = []
+        for entry in entries:
+            section_text = _build_comment_section(entry, max_section_len)
+            sections.append((section_text, entry))
+
+        # Chunk sections into posts that fit within the size limit
+        chunks = _chunk_sections(header, sections, max_len)
+
+        # Post each chunk
+        for chunk_idx, chunk in enumerate(chunks):
+            success, chunk_updates = _post_chunk(
+                owner, repo, pr_number, reviewer, chunk, header, chunk_idx, len(chunks), max_len
+            )
+            if success:
+                posted += 1
+                posted_updates.extend(chunk_updates)
+
+    return posted, posted_updates
+
+
 def run(json_path: str) -> None:
     """Main entry point.
 
@@ -310,6 +508,9 @@ def run(json_path: str) -> None:
     nitpick_count = 0
     duplicate_count = 0
 
+    # Collect body comments for consolidated PR comments
+    body_comments_by_reviewer: dict[str, list[dict[str, Any]]] = {}
+
     # Track updates for atomic application
     updates: list[dict[str, Any]] = []
 
@@ -342,16 +543,32 @@ def run(json_path: str) -> None:
                     pending_count += 1
                     eprint(f"Skipping {category}[{i}] ({path}): {comment_type} status is pending")
                     continue
-                if status in ("addressed", "not_addressed", "skipped"):
-                    if comment_type == "outside_diff_comment":
-                        outside_diff_count += 1
-                    elif comment_type == "nitpick_comment":
-                        nitpick_count += 1
-                    else:
-                        duplicate_count += 1
+                if status in ("addressed", "not_addressed", "skipped", "failed"):
+                    # Skip if already posted (idempotency)
+                    if posted_at:
+                        already_posted_count += 1
+                        eprint(f"Skipping {category}[{i}] ({path}): {comment_type} already posted at {posted_at}")
+                        continue
+
+                    # Skip auto-skipped entries — they were already replied to in a previous cycle
+                    if thread_data.get("is_auto_skipped"):
+                        already_posted_count += 1
+                        eprint(
+                            f"Skipping {category}[{i}] ({path}): {comment_type}"
+                            " auto-skipped (already replied in previous cycle)"
+                        )
+                        continue
+
+                    # Collect for consolidated PR comment (counts tracked after posting)
+                    author_raw = thread_data.get("author")
+                    author = author_raw.strip() if isinstance(author_raw, str) and author_raw.strip() else "unknown"
+                    if author not in body_comments_by_reviewer:
+                        body_comments_by_reviewer[author] = []
+                    body_comments_by_reviewer[author].append({"data": thread_data, "cat": category, "idx": i})
+
                     eprint(
                         f"{comment_type.replace('_', ' ').title()} {category}[{i}] ({path})"
-                        " - no thread to post to, will be tracked via review database"
+                        " - collected for consolidated PR comment"
                     )
                     continue
                 # Unknown status - skip with warning
@@ -464,6 +681,30 @@ def run(json_path: str) -> None:
                 replied_not_resolved_count += 1
                 eprint(f"Replied to {category}[{i}] ({path}) (not resolved)")
 
+    # Post consolidated PR comments for body comments
+    if body_comments_by_reviewer:
+        total_body = sum(len(c) for c in body_comments_by_reviewer.values())
+        eprint(f"\nPosting consolidated replies for {total_body} body comment(s)...")
+        _, body_updates = post_body_comment_replies(owner, repo, pr_number, body_comments_by_reviewer)
+        updates.extend(body_updates)
+
+        # Count successfully posted body comments by type
+        for update in body_updates:
+            cat = update["cat"]
+            idx = update["idx"]
+            comment_data = data.get(cat, [])[idx] if idx < len(data.get(cat, [])) else {}
+            comment_type = comment_data.get("type", "")
+            if comment_type == "outside_diff_comment":
+                outside_diff_count += 1
+            elif comment_type == "nitpick_comment":
+                nitpick_count += 1
+            elif comment_type == "duplicate_comment":
+                duplicate_count += 1
+
+        body_comment_failed = total_body - len(body_updates)
+        if body_comment_failed > 0:
+            failed_count += body_comment_failed
+
     # Apply all JSON updates atomically
     apply_updates_to_json(json_path_obj, updates)
 
@@ -479,13 +720,13 @@ def run(json_path: str) -> None:
         eprint(f"  Replied only: {replied_not_resolved_count} (human reviews - awaiting reviewer follow-up)")
 
     if outside_diff_count > 0:
-        eprint(f"  Outside-diff: {outside_diff_count} (tracked in review database, no thread to post to)")
+        eprint(f"  Outside-diff: {outside_diff_count} (replied via consolidated PR comment)")
 
     if nitpick_count > 0:
-        eprint(f"  Nitpick: {nitpick_count} (tracked in review database, no thread to post to)")
+        eprint(f"  Nitpick: {nitpick_count} (replied via consolidated PR comment)")
 
     if duplicate_count > 0:
-        eprint(f"  Duplicate: {duplicate_count} (tracked in review database, no thread to post to)")
+        eprint(f"  Duplicate: {duplicate_count} (replied via consolidated PR comment)")
 
     if pending_count > 0:
         eprint(f"  Pending: {pending_count} threads (not processed yet)")

--- a/plugins/myk-github/commands/review-handler.md
+++ b/plugins/myk-github/commands/review-handler.md
@@ -190,6 +190,14 @@ Update each JSON entry with `status` and `reply` fields before posting.
 - User said **skip ai** → `skipped` for all remaining AI sources
   (include the user's skip reason in `reply`)
 
+**Body comments (outside-diff, nitpick, duplicate):**
+
+Comments that don't have GitHub review threads (e.g., CodeRabbit outside-diff,
+nitpick, and duplicate comments) are replied to via a single consolidated PR
+comment per reviewer. The comment mentions the reviewer (e.g., `@coderabbitai`)
+and includes sections for each comment with the decision made. This ensures
+automated reviewers know their comments were reviewed and won't re-raise them.
+
 Post replies to GitHub:
 
 ```bash

--- a/tests/test_post_review_replies.py
+++ b/tests/test_post_review_replies.py
@@ -1079,11 +1079,16 @@ class TestOutsideDiffCommentHandling:
         json_path.write_text(json.dumps(data))
         return json_path
 
+    @patch.object(
+        post_review_replies,
+        "post_body_comment_replies",
+        return_value=(1, [{"cat": "coderabbit", "idx": 0, "field": "posted_at", "ts": "2024-01-01T00:00:00Z"}]),
+    )
     @patch.object(post_review_replies, "resolve_thread")
     @patch.object(post_review_replies, "post_thread_reply")
     @patch.object(post_review_replies, "check_dependencies")
     def test_outside_diff_addressed_no_post(
-        self, mock_deps: Any, mock_post: Any, mock_resolve: Any, tmp_path: Path
+        self, mock_deps: Any, mock_post: Any, mock_resolve: Any, mock_body: Any, tmp_path: Path
     ) -> None:
         """Outside-diff comments with addressed status should not post or resolve."""
         del mock_deps  # Injected by @patch decorator, unused in test
@@ -1099,6 +1104,7 @@ class TestOutsideDiffCommentHandling:
                         "status": "addressed",
                         "reply": "Fixed",
                         "path": "src/main.py",
+                        "author": "coderabbitai[bot]",
                     }
                 ],
             },
@@ -1110,12 +1116,25 @@ class TestOutsideDiffCommentHandling:
         assert excinfo.value.code == 0
         mock_post.assert_not_called()
         mock_resolve.assert_not_called()
+        # Verify body comment was posted via consolidated PR comment
+        mock_body.assert_called_once()
+        args = mock_body.call_args.args
+        assert args[0] == "test-owner"
+        assert args[1] == "test-repo"
+        assert args[2] == "123"
+        grouped = args[3]
+        assert "coderabbitai[bot]" in grouped
 
+    @patch.object(
+        post_review_replies,
+        "post_body_comment_replies",
+        return_value=(1, [{"cat": "coderabbit", "idx": 0, "field": "posted_at", "ts": "2024-01-01T00:00:00Z"}]),
+    )
     @patch.object(post_review_replies, "resolve_thread")
     @patch.object(post_review_replies, "post_thread_reply")
     @patch.object(post_review_replies, "check_dependencies")
     def test_outside_diff_not_addressed_no_post(
-        self, mock_deps: Any, mock_post: Any, mock_resolve: Any, tmp_path: Path
+        self, mock_deps: Any, mock_post: Any, mock_resolve: Any, mock_body: Any, tmp_path: Path
     ) -> None:
         """Outside-diff comments with not_addressed status should not post or resolve."""
         del mock_deps  # Injected by @patch decorator, unused in test
@@ -1131,6 +1150,7 @@ class TestOutsideDiffCommentHandling:
                         "status": "not_addressed",
                         "reply": "Cannot fix",
                         "path": "src/main.py",
+                        "author": "coderabbitai[bot]",
                     }
                 ],
             },
@@ -1142,12 +1162,25 @@ class TestOutsideDiffCommentHandling:
         assert excinfo.value.code == 0
         mock_post.assert_not_called()
         mock_resolve.assert_not_called()
+        # Verify body comment was posted via consolidated PR comment
+        mock_body.assert_called_once()
+        args = mock_body.call_args.args
+        assert args[0] == "test-owner"
+        assert args[1] == "test-repo"
+        assert args[2] == "123"
+        grouped = args[3]
+        assert "coderabbitai[bot]" in grouped
 
+    @patch.object(
+        post_review_replies,
+        "post_body_comment_replies",
+        return_value=(1, [{"cat": "coderabbit", "idx": 0, "field": "posted_at", "ts": "2024-01-01T00:00:00Z"}]),
+    )
     @patch.object(post_review_replies, "resolve_thread")
     @patch.object(post_review_replies, "post_thread_reply")
     @patch.object(post_review_replies, "check_dependencies")
     def test_outside_diff_skipped_no_post(
-        self, mock_deps: Any, mock_post: Any, mock_resolve: Any, tmp_path: Path
+        self, mock_deps: Any, mock_post: Any, mock_resolve: Any, mock_body: Any, tmp_path: Path
     ) -> None:
         """Outside-diff comments with skipped status should not post or resolve."""
         del mock_deps  # Injected by @patch decorator, unused in test
@@ -1163,6 +1196,7 @@ class TestOutsideDiffCommentHandling:
                         "status": "skipped",
                         "skip_reason": "Out of scope",
                         "path": "src/main.py",
+                        "author": "coderabbitai[bot]",
                     }
                 ],
             },
@@ -1174,12 +1208,21 @@ class TestOutsideDiffCommentHandling:
         assert excinfo.value.code == 0
         mock_post.assert_not_called()
         mock_resolve.assert_not_called()
+        # Verify body comment was posted via consolidated PR comment
+        mock_body.assert_called_once()
+        args = mock_body.call_args.args
+        assert args[0] == "test-owner"
+        assert args[1] == "test-repo"
+        assert args[2] == "123"
+        grouped = args[3]
+        assert "coderabbitai[bot]" in grouped
 
+    @patch.object(post_review_replies, "post_body_comment_replies")
     @patch.object(post_review_replies, "resolve_thread")
     @patch.object(post_review_replies, "post_thread_reply")
     @patch.object(post_review_replies, "check_dependencies")
     def test_outside_diff_pending_skipped(
-        self, mock_deps: Any, mock_post: Any, mock_resolve: Any, tmp_path: Path
+        self, mock_deps: Any, mock_post: Any, mock_resolve: Any, mock_body: Any, tmp_path: Path
     ) -> None:
         """Outside-diff comments with pending status should be skipped."""
         del mock_deps  # Injected by @patch decorator, unused in test
@@ -1205,14 +1248,21 @@ class TestOutsideDiffCommentHandling:
         assert excinfo.value.code == 0
         mock_post.assert_not_called()
         mock_resolve.assert_not_called()
+        # Pending comments should not trigger body comment posting
+        mock_body.assert_not_called()
 
+    @patch.object(
+        post_review_replies,
+        "post_body_comment_replies",
+        return_value=(1, [{"cat": "coderabbit", "idx": 0, "field": "posted_at", "ts": "2024-01-01T00:00:00Z"}]),
+    )
     @patch.object(post_review_replies, "resolve_thread")
     @patch.object(post_review_replies, "post_thread_reply")
     @patch.object(post_review_replies, "check_dependencies")
-    def test_outside_diff_failed_status_warning(
-        self, mock_deps: Any, mock_post: Any, mock_resolve: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    def test_outside_diff_failed_collected_for_body_comment(
+        self, mock_deps: Any, mock_post: Any, mock_resolve: Any, mock_body: Any, tmp_path: Path
     ) -> None:
-        """Failed status on outside-diff comment should trigger unknown status warning."""
+        """Failed status on outside-diff comment should be collected for consolidated PR comment."""
         del mock_deps  # Injected by @patch decorator, unused in test
         json_path = self._create_test_json(
             tmp_path,
@@ -1226,6 +1276,7 @@ class TestOutsideDiffCommentHandling:
                         "status": "failed",
                         "reply": "Retry needed",
                         "path": "src/main.py",
+                        "author": "coderabbitai[bot]",
                     }
                 ],
             },
@@ -1237,15 +1288,31 @@ class TestOutsideDiffCommentHandling:
         assert excinfo.value.code == 0
         mock_post.assert_not_called()
         mock_resolve.assert_not_called()
+        # Verify body comment was posted via consolidated PR comment
+        mock_body.assert_called_once()
+        args = mock_body.call_args.args
+        assert args[0] == "test-owner"
+        assert args[1] == "test-repo"
+        assert args[2] == "123"
+        grouped = args[3]
+        assert "coderabbitai[bot]" in grouped
 
-        captured = capsys.readouterr()
-        assert "unknown status" in captured.err.lower()
-
+    @patch.object(
+        post_review_replies,
+        "post_body_comment_replies",
+        return_value=(1, [{"cat": "coderabbit", "idx": 0, "field": "posted_at", "ts": "2024-01-01T00:00:00Z"}]),
+    )
     @patch.object(post_review_replies, "resolve_thread")
     @patch.object(post_review_replies, "post_thread_reply")
     @patch.object(post_review_replies, "check_dependencies")
     def test_outside_diff_not_counted_as_no_thread_id(
-        self, mock_deps: Any, mock_post: Any, mock_resolve: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+        self,
+        mock_deps: Any,
+        mock_post: Any,
+        mock_resolve: Any,
+        mock_body: Any,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
         """Outside-diff comments should not appear in no_thread_id count."""
         del mock_deps  # Injected by @patch decorator, unused in test
@@ -1261,6 +1328,7 @@ class TestOutsideDiffCommentHandling:
                         "status": "addressed",
                         "reply": "Done",
                         "path": "src/main.py",
+                        "author": "coderabbitai[bot]",
                     }
                 ],
             },
@@ -1279,4 +1347,170 @@ class TestOutsideDiffCommentHandling:
         assert "no thread_id" not in captured.err.lower()
         # Should mention outside-diff tracking
         assert "outside-diff" in captured.err.lower()
-        assert "review database" in captured.err.lower()
+        assert "consolidated pr comment" in captured.err.lower()
+        # Verify body comment was posted via consolidated PR comment
+        mock_body.assert_called_once()
+        args = mock_body.call_args.args
+        assert args[0] == "test-owner"
+        assert args[1] == "test-repo"
+        assert args[2] == "123"
+        grouped = args[3]
+        assert "coderabbitai[bot]" in grouped
+
+
+# =============================================================================
+# Tests for post_body_comment_replies() chunking logic
+# =============================================================================
+
+
+class TestPostBodyCommentChunking:
+    """Tests for chunking boundary behavior in post_body_comment_replies()."""
+
+    @staticmethod
+    def _make_entry(reply: str, idx: int = 0, path: str = "src/main.py", status: str = "addressed") -> dict[str, Any]:
+        """Helper to create a body comment entry dict."""
+        return {
+            "data": {
+                "path": path,
+                "line": 10,
+                "status": status,
+                "reply": reply,
+                "type": "outside_diff_comment",
+                "body": "Original comment body",
+            },
+            "cat": "coderabbit",
+            "idx": idx,
+        }
+
+    @patch("subprocess.run")
+    def test_single_small_comment_fits_one_chunk(self, mock_run: Any) -> None:
+        """A single small comment should produce exactly one API call."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+
+        body_comments = {"coderabbitai[bot]": [self._make_entry(reply="Fixed this issue", idx=0)]}
+
+        posted, updates = post_review_replies.post_body_comment_replies("test-owner", "test-repo", "123", body_comments)
+
+        assert posted == 1
+        assert len(updates) == 1
+        assert updates[0]["cat"] == "coderabbit"
+        assert updates[0]["idx"] == 0
+        assert updates[0]["field"] == "posted_at"
+        # Exactly one API call
+        assert mock_run.call_count == 1
+        # Verify posted body does not contain "(Part" prefix since it fits in one chunk
+        call_args = mock_run.call_args
+        body_arg = [a for a in call_args.args[0] if isinstance(a, str) and a.startswith("body=")]
+        assert len(body_arg) == 1
+        assert "(Part" not in body_arg[0]
+
+    @patch("subprocess.run")
+    def test_multiple_small_comments_fit_one_chunk(self, mock_run: Any) -> None:
+        """Multiple small comments that fit within max_len should produce one API call."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+
+        entries = [self._make_entry(reply=f"Fixed issue {i}", idx=i, path=f"src/file{i}.py") for i in range(5)]
+        body_comments = {"coderabbitai[bot]": entries}
+
+        posted, updates = post_review_replies.post_body_comment_replies("test-owner", "test-repo", "123", body_comments)
+
+        assert posted == 1
+        assert len(updates) == 5
+        assert mock_run.call_count == 1
+
+    @patch("subprocess.run")
+    def test_large_comments_split_into_multiple_chunks(self, mock_run: Any) -> None:
+        """Comments exceeding max_len should be split into multiple API calls."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+
+        # Each reply is ~10000 chars; max_len is 55000, so 7 entries should require 2 chunks
+        large_reply = "x" * 10000
+        entries = [self._make_entry(reply=large_reply, idx=i, path=f"src/file{i}.py") for i in range(7)]
+        body_comments = {"coderabbitai[bot]": entries}
+
+        posted, updates = post_review_replies.post_body_comment_replies("test-owner", "test-repo", "123", body_comments)
+
+        assert posted == 2
+        assert len(updates) == 7
+        assert mock_run.call_count == 2
+        # Verify "(Part" prefix is present in multi-chunk posts
+        for call in mock_run.call_args_list:
+            cmd_args = call.args[0]
+            body_parts = [a for a in cmd_args if isinstance(a, str) and a.startswith("body=")]
+            assert len(body_parts) == 1
+            assert "(Part" in body_parts[0]
+
+    @patch("subprocess.run")
+    def test_single_oversized_comment_not_split(self, mock_run: Any) -> None:
+        """A single comment that exceeds max_len should still be posted in one chunk."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+
+        # Reply of 60000 chars exceeds 55000 max_len but it's a single entry
+        oversized_reply = "y" * 60000
+        body_comments = {"coderabbitai[bot]": [self._make_entry(reply=oversized_reply, idx=0)]}
+
+        posted, updates = post_review_replies.post_body_comment_replies("test-owner", "test-repo", "123", body_comments)
+
+        assert posted == 1
+        assert len(updates) == 1
+        # Only one API call since a single section cannot be split further
+        assert mock_run.call_count == 1
+
+    @patch("subprocess.run")
+    def test_multiple_reviewers_post_separately(self, mock_run: Any) -> None:
+        """Each reviewer should get their own consolidated comment(s)."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+
+        body_comments = {
+            "coderabbitai[bot]": [self._make_entry(reply="Fixed", idx=0)],
+            "qodo-ai[bot]": [self._make_entry(reply="Addressed", idx=1)],
+        }
+
+        posted, updates = post_review_replies.post_body_comment_replies("test-owner", "test-repo", "123", body_comments)
+
+        assert posted == 2
+        assert len(updates) == 2
+        assert mock_run.call_count == 2
+
+    @patch("subprocess.run")
+    def test_api_failure_returns_no_updates(self, mock_run: Any) -> None:
+        """Failed API calls should not produce posted_at updates."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="API error")
+
+        body_comments = {"coderabbitai[bot]": [self._make_entry(reply="Fixed", idx=0)]}
+
+        posted, updates = post_review_replies.post_body_comment_replies("test-owner", "test-repo", "123", body_comments)
+
+        assert posted == 0
+        assert len(updates) == 0
+
+    @patch("subprocess.run")
+    def test_empty_entries_skipped(self, mock_run: Any) -> None:
+        """Empty entry list for a reviewer should not produce any API call."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+
+        body_comments: dict[str, list[dict[str, Any]]] = {"coderabbitai[bot]": []}
+
+        posted, updates = post_review_replies.post_body_comment_replies("test-owner", "test-repo", "123", body_comments)
+
+        assert posted == 0
+        assert len(updates) == 0
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_chunk_boundary_exact_fit(self, mock_run: Any) -> None:
+        """Comments that fit within max_len should produce a single chunk."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+
+        # Build entries that together are under the 55000 limit
+        # Header is ~80 chars, each section is ~200 chars base + reply length
+        reply_size = 5000
+        # 10 entries * ~5200 per section = ~52000 + header ~80 = ~52080 < 55000
+        entries = [self._make_entry(reply="z" * reply_size, idx=i, path=f"src/f{i}.py") for i in range(10)]
+        body_comments = {"coderabbitai[bot]": entries}
+
+        posted, updates = post_review_replies.post_body_comment_replies("test-owner", "test-repo", "123", body_comments)
+
+        assert posted == 1
+        assert len(updates) == 10
+        assert mock_run.call_count == 1


### PR DESCRIPTION
## Summary
- Post consolidated PR comments for outside-diff, nitpick, and duplicate comments that don't have GitHub review threads
- Groups by reviewer author and mentions them (e.g., `@coderabbitai`) so automated reviewers know comments were reviewed
- Ensures skipped/not-addressed comments won't be re-raised on subsequent pushes

## Implementation
- New `post_body_comment_replies()` function in `reviews/post.py`
- Chunks comments per reviewer at 55KB boundary to stay within GitHub's size limit
- Idempotent: skips entries with `posted_at` already set, writes timestamps back on success
- Failures propagate to exit code (entry-count-based tracking)
- Summary counters only reflect actually posted entries

## Test plan
- [x] Existing 638 tests pass
- [x] Peer reviewed via Cursor (4 rounds, 5 findings addressed)
- [ ] Manual test with a real PR that has CodeRabbit body comments

Closes #167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated posting of review body comments per reviewer, with automatic chunking for large sets and per-reviewer consolidated replies.

* **Bug Fixes**
  * More robust posting with fallbacks, retry-aware outcomes, handling for already-posted/failed items, and clearer aggregated summary counts plus runtime messaging.

* **Documentation**
  * Updated workflow guidance showing consolidated comment posting and post-run behavior.

* **Tests**
  * Added/expanded tests for consolidation, chunking boundaries, posting outcomes, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->