### PR TITLE
feat(review-handler): show original status for auto-skipped comments

### DIFF
--- a/myk_claude_tools/db/query.py
+++ b/myk_claude_tools/db/query.py
@@ -207,7 +207,7 @@ class ReviewDB:
 
         Returns:
             List of dicts with keys: path, line, body, status, reply (reason for dismissal),
-            comment_id (GitHub comment/review ID for exact matching).
+            skip_reason (raw reason without formatting), comment_id (GitHub comment/review ID for exact matching).
             Returns empty list if database doesn't exist or on error.
 
         Example:
@@ -246,6 +246,7 @@ class ReviewDB:
                     "body": row["body"],
                     "status": row["status"],
                     "reply": row["reply"] or row["skip_reason"],
+                    "skip_reason": row["skip_reason"],
                     "author": row["author"],
                     "type": row["type"],
                     "comment_id": row["comment_id"],

--- a/myk_claude_tools/reviews/fetch.py
+++ b/myk_claude_tools/reviews/fetch.py
@@ -730,11 +730,13 @@ def process_and_categorize(threads: list[dict[str, Any]], owner: str, repo: str)
                                     break
 
                         if best:
-                            reason = (best.get("reply") or "").strip()
+                            reason = (best.get("skip_reason") or best.get("reply") or "").strip()
                             if reason:
+                                original_status = best.get("status", "skipped")
                                 enriched["status"] = "skipped"
                                 enriched["skip_reason"] = reason
-                                enriched["reply"] = f"Auto-skipped: Previously dismissed - {reason}"
+                                enriched["original_status"] = original_status  # Display-only, not persisted to DB
+                                enriched["reply"] = f"Auto-skipped ({original_status}): {reason}"
                                 enriched["is_auto_skipped"] = True
                 except Exception as e:
                     print_stderr(f"Warning: Failed to match dismissed comment: {e}")

--- a/plugins/myk-github/commands/review-handler.md
+++ b/plugins/myk-github/commands/review-handler.md
@@ -82,9 +82,10 @@ Use a **global counter** for the `#` column across all tables (not per-table).
 |---|----------|------|------|---------|--------|
 | 1 | HIGH | src/storage.py | 231 | Backfill destroys historical chronology | Pending |
 | 2 | MEDIUM | src/html_report.py | 1141 | Add/delete leaves badges stale | Pending |
-| 3 | LOW | src/utils.py | 42 | Unused import | Auto-skipped: "style only" |
+| 3 | LOW | src/utils.py | 42 | Unused import | Auto-skipped (skipped): "style only" |
+| 4 | LOW | src/config.py | 15 | Missing validation | Auto-skipped (addressed): "added in prev PR" |
 
-(Numbering continues across tables — e.g., if this table ends at 3, the next table starts at 4.)
+(Numbering continues across tables — e.g., if this table ends at 4, the next table starts at 5.)
 ```
 
 **Table rules:**
@@ -94,7 +95,7 @@ Use a **global counter** for the `#` column across all tables (not per-table).
   Include "Also applies to" references if present
 - **Status column values:**
   - `Pending` — awaiting user decision
-  - `Auto-skipped: "{reason}"` — previously dismissed, showing the stored reason
+  - `Auto-skipped ({original_status}): "{reason}"` — showing the original status (addressed/skipped/not_addressed) and the stored reason
 - **Every item gets a row** — including auto-skipped items so the user can override
 
 **After presenting all tables, show the response options:**


### PR DESCRIPTION
## Summary\n- Auto-skipped comments now display whether they were previously \"addressed\", \"skipped\", or \"not_addressed\" instead of a generic \"Auto-skipped\" label\n- Prefers raw `skip_reason` over formatted `reply` to prevent banner nesting across review cycles\n- Added `skip_reason` as a separate field in `get_dismissed_comments()` return dict\n\n## Test plan\n- [x] All 646 existing tests pass\n- [x] Reviewed by 3 parallel code review agents\n- [x] Peer-reviewed via Cursor AI (4 rounds, all findings resolved)\n\nCloses #170