### PR TITLE
chore: bump version to 1.4.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,25 +8,25 @@
       "name": "myk-qodo",
       "source": "./plugins/myk-qodo",
       "description": "Qodo AI code review integration",
-      "version": "1.4.5"
+      "version": "1.4.6"
     },
     {
       "name": "myk-github",
       "source": "./plugins/myk-github",
       "description": "GitHub operations - PR reviews, releases, review handling, CodeRabbit rate limits",
-      "version": "1.4.5"
+      "version": "1.4.6"
     },
     {
       "name": "myk-review",
       "source": "./plugins/myk-review",
       "description": "Local code review and review database operations",
-      "version": "1.4.5"
+      "version": "1.4.6"
     },
     {
       "name": "myk-cursor",
       "source": "./plugins/myk-cursor",
       "description": "Run prompts via Cursor agent CLI with optional --fix mode for direct file changes",
-      "version": "1.4.5"
+      "version": "1.4.6"
     }
   ]
 }

--- a/myk_claude_tools/__init__.py
+++ b/myk_claude_tools/__init__.py
@@ -1,3 +1,3 @@
 """myk-claude-tools: CLI utilities for Claude Code plugins."""
 
-__version__ = "1.4.5"
+__version__ = "1.4.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "myk-claude-tools"
-version = "1.4.5"
+version = "1.4.6"
 description = "CLI utilities for Claude Code plugins"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bump version to 1.4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.4.6 across all plugins and packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->