### PR TITLE
chore: bump version to 1.9.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,19 +8,19 @@
       "name": "myk-github",
       "source": "./plugins/myk-github",
       "description": "GitHub operations - PR reviews, releases, review handling, CodeRabbit rate limits",
-      "version": "1.9.2"
+      "version": "1.9.3"
     },
     {
       "name": "myk-review",
       "source": "./plugins/myk-review",
       "description": "Local code review and review database operations",
-      "version": "1.9.2"
+      "version": "1.9.3"
     },
     {
       "name": "myk-acpx",
       "source": "./plugins/myk-acpx",
       "description": "Multi-agent prompt execution via acpx (Agent Client Protocol)",
-      "version": "1.9.2"
+      "version": "1.9.3"
     }
   ]
 }

--- a/myk_claude_tools/__init__.py
+++ b/myk_claude_tools/__init__.py
@@ -1,3 +1,3 @@
 """myk-claude-tools: CLI utilities for Claude Code plugins."""
 
-__version__ = "1.9.2"
+__version__ = "1.9.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "myk-claude-tools"
-version = "1.9.2"
+version = "1.9.3"
 description = "CLI utilities for Claude Code plugins"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "myk-claude-tools"
-version = "1.9.2"
+version = "1.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bump version to 1.9.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped from 1.9.2 to 1.9.3 for the package and all integrated plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->